### PR TITLE
Add configuration local app data support

### DIFF
--- a/FlashSearch.CLI/Program.cs
+++ b/FlashSearch.CLI/Program.cs
@@ -58,11 +58,13 @@ namespace FlashSearch.CLI
     internal class Program
     {
         private static String ConfigFilePath = null;
+        private static ConfigurationPathResolver _configPathResolver;
         private static ConsoleWriter _console;
         
         private static SearchConfiguration LoadConfiguration()
         {
-            ConfigFilePath = ConfigurationPathResolver.GetConfigurationPath();
+            _configPathResolver = new ConfigurationPathResolver();
+            ConfigFilePath = _configPathResolver.GetConfigurationPath();
             var watcher = new ConfigurationWatcher<SearchConfiguration>(
                 ConfigFilePath,
                 XMLIO.Load<SearchConfiguration>,
@@ -159,7 +161,7 @@ namespace FlashSearch.CLI
 
             SmartContentSelector contentSelector = new SmartContentSelector(options.Query, options.CaseSensitive);
             
-            string indexDirectory = ConfigurationPathResolver.GetIndexDir(project.Name, fileFilter.Index);
+            string indexDirectory = _configPathResolver.GetIndexDir(project.Name, fileFilter.Index);
             var luceneSearcher = new LuceneSearcher(indexDirectory) {MaxSearchResults = Int32.MaxValue};
             foreach (var result in luceneSearcher.SearchContentInFolder(path, fileSelector, contentSelector))
             {
@@ -198,7 +200,7 @@ namespace FlashSearch.CLI
 
             LuceneContentSelector contentSelector = new LuceneContentSelector(options.Query);
             
-            string indexDirectory = ConfigurationPathResolver.GetIndexDir(project.Name, fileFilter.Index);
+            string indexDirectory = _configPathResolver.GetIndexDir(project.Name, fileFilter.Index);
             var luceneSearcher = new LuceneSearcher(indexDirectory) {MaxSearchResults = Int32.MaxValue};
             foreach (var result in luceneSearcher.SearchContentInFolder(path, fileSelector, contentSelector))
             {
@@ -233,7 +235,7 @@ namespace FlashSearch.CLI
                 .WithMaxSize(config.MaxFileSize)
                 .Build();
             
-            string indexDirectory = ConfigurationPathResolver.GetIndexDir(project.Name, fileFilter.Index);
+            string indexDirectory = _configPathResolver.GetIndexDir(project.Name, fileFilter.Index);
             var luceneSearcher = new LuceneSearcher(indexDirectory);
 
             Console.Write($"Indexing {path}...");

--- a/FlashSearch.CLI/Program.cs
+++ b/FlashSearch.CLI/Program.cs
@@ -57,13 +57,14 @@ namespace FlashSearch.CLI
     
     internal class Program
     {
-        private static readonly String ConfigFileName = "SearchConfiguration.xml";
+        private static String ConfigFilePath = null;
         private static ConsoleWriter _console;
         
         private static SearchConfiguration LoadConfiguration()
         {
+            ConfigFilePath = ConfigurationPathResolver.GetConfigurationPath();
             var watcher = new ConfigurationWatcher<SearchConfiguration>(
-                GetConfigurationPath(),
+                ConfigFilePath,
                 XMLIO.Load<SearchConfiguration>,
                 XMLIO.Save,
                 () => SearchConfiguration.Default);
@@ -97,7 +98,7 @@ namespace FlashSearch.CLI
                 FileFilter fileFilter = config.FileFilters.First(filter =>
                     filter.Name.Equals(options.FileFilterName, StringComparison.InvariantCultureIgnoreCase));
                 if (fileFilter == null)
-                    throw new ArgumentException($"File filter named '{options.FileFilterName}' does not exist. Please edit '{ConfigFileName}'.");
+                    throw new ArgumentException($"File filter named '{options.FileFilterName}' does not exist. Please edit '{ConfigFilePath}'.");
                 
                 fileSelector = ExtensibleFileSelectorBuilder.NewFileSelector()
                     .WithoutExcludedExtensions()
@@ -139,14 +140,14 @@ namespace FlashSearch.CLI
                 p => path.StartsWith(p.Path, StringComparison.InvariantCultureIgnoreCase));
 
             if (project == null)
-                throw new ArgumentException($"Current path is not under any known project. Please edit '{ConfigFileName}'.");
+                throw new ArgumentException($"Current path is not under any known project. Please edit '{ConfigFilePath}'.");
 
 
             FileFilter fileFilter = config.FileFilters.FirstOrDefault(filter =>
                 filter.Name.Equals(options.FileFilterName, StringComparison.InvariantCultureIgnoreCase));
 
             if (fileFilter == null)
-                throw new ArgumentException($"File filter named '{options.FileFilterName}' does not exist. Please edit '{ConfigFileName}'.");
+                throw new ArgumentException($"File filter named '{options.FileFilterName}' does not exist. Please edit '{ConfigFilePath}'.");
 
             var fileSelector = ExtensibleFileSelectorBuilder.NewFileSelector()
                 .WithExcludedExtensions(config.ExcludedExtensions)
@@ -158,8 +159,7 @@ namespace FlashSearch.CLI
 
             SmartContentSelector contentSelector = new SmartContentSelector(options.Query, options.CaseSensitive);
             
-            string localDirectory = Path.GetDirectoryName(Assembly.GetExecutingAssembly().Location);
-            string indexDirectory = Path.Combine(localDirectory, "Indexes", project.Name, fileFilter.Index);
+            string indexDirectory = ConfigurationPathResolver.GetIndexDir(project.Name, fileFilter.Index);
             var luceneSearcher = new LuceneSearcher(indexDirectory) {MaxSearchResults = Int32.MaxValue};
             foreach (var result in luceneSearcher.SearchContentInFolder(path, fileSelector, contentSelector))
             {
@@ -179,14 +179,14 @@ namespace FlashSearch.CLI
                 p => path.StartsWith(p.Path, StringComparison.InvariantCultureIgnoreCase));
 
             if (project == null)
-                throw new ArgumentException($"Current path is not under any known project. Please edit '{ConfigFileName}'.");
+                throw new ArgumentException($"Current path is not under any known project. Please edit '{ConfigFilePath}'.");
 
 
             FileFilter fileFilter = config.FileFilters.FirstOrDefault(filter =>
                 filter.Name.Equals(options.FileFilterName, StringComparison.InvariantCultureIgnoreCase));
 
             if (fileFilter == null)
-                throw new ArgumentException($"File filter named '{options.FileFilterName}' does not exist. Please edit '{ConfigFileName}'.");
+                throw new ArgumentException($"File filter named '{options.FileFilterName}' does not exist. Please edit '{ConfigFilePath}'.");
 
             var fileSelector = ExtensibleFileSelectorBuilder.NewFileSelector()
                 .WithExcludedExtensions(config.ExcludedExtensions)
@@ -198,8 +198,7 @@ namespace FlashSearch.CLI
 
             LuceneContentSelector contentSelector = new LuceneContentSelector(options.Query);
             
-            string localDirectory = Path.GetDirectoryName(Assembly.GetExecutingAssembly().Location);
-            string indexDirectory = Path.Combine(localDirectory, "Indexes", project.Name, fileFilter.Index);
+            string indexDirectory = ConfigurationPathResolver.GetIndexDir(project.Name, fileFilter.Index);
             var luceneSearcher = new LuceneSearcher(indexDirectory) {MaxSearchResults = Int32.MaxValue};
             foreach (var result in luceneSearcher.SearchContentInFolder(path, fileSelector, contentSelector))
             {
@@ -218,13 +217,13 @@ namespace FlashSearch.CLI
                 p => path.StartsWith(p.Path, StringComparison.InvariantCultureIgnoreCase));
 
             if (project == null)
-                throw new ArgumentException($"Current path is not under any known project. Please edit '{ConfigFileName}'.");
+                throw new ArgumentException($"Current path is not under any known project. Please edit '{ConfigFilePath}'.");
 
             FileFilter fileFilter = config.FileFilters.FirstOrDefault(filter =>
                 filter.Name.Equals(options.FileFilterName, StringComparison.InvariantCultureIgnoreCase));
 
             if (fileFilter == null)
-                throw new ArgumentException($"File filter named '{options.FileFilterName}' does not exist. Please edit '{ConfigFileName}'.");
+                throw new ArgumentException($"File filter named '{options.FileFilterName}' does not exist. Please edit '{ConfigFilePath}'.");
 
             var fileSelector = ExtensibleFileSelectorBuilder.NewFileSelector()
                 .WithExcludedExtensions(config.ExcludedExtensions)
@@ -234,8 +233,7 @@ namespace FlashSearch.CLI
                 .WithMaxSize(config.MaxFileSize)
                 .Build();
             
-            string localDirectory = Path.GetDirectoryName(Assembly.GetExecutingAssembly().Location);
-            string indexDirectory = Path.Combine(localDirectory, "Indexes", project.Name, fileFilter.Index);
+            string indexDirectory = ConfigurationPathResolver.GetIndexDir(project.Name, fileFilter.Index);
             var luceneSearcher = new LuceneSearcher(indexDirectory);
 
             Console.Write($"Indexing {path}...");
@@ -274,14 +272,6 @@ namespace FlashSearch.CLI
             _console.Write("\nSearch cancelled by user.\n", ConsoleColor.Red, true);
             Console.ResetColor();
             System.Environment.Exit(0);
-        }
-        
-        private static string GetConfigurationPath()
-        {
-            string directoryName = Path.GetDirectoryName(Assembly.GetExecutingAssembly().Location);
-            if (String.IsNullOrEmpty(directoryName))
-                throw new Exception("Unable to find executable's directory.");
-            return Path.Combine(directoryName, ConfigFileName);
         }
     }
     

--- a/FlashSearch.Configuration/ConfigurationPathResolver.cs
+++ b/FlashSearch.Configuration/ConfigurationPathResolver.cs
@@ -1,0 +1,71 @@
+using System;
+using System.IO;
+using System.Reflection;
+
+namespace FlashSearch.Configuration
+{
+    public static class ConfigurationPathResolver
+    {
+        private static readonly String ConfigFileName = "SearchConfiguration.xml";
+        private static string ConfigFilePath = null;
+        private static string IndexesDir = null;
+
+        public static string GetConfigurationPath()
+        {
+            ResolvePathsIfEmpty();
+            return ConfigFilePath;
+        }
+
+        public static string GetIndexDir(string projectName, string fileFilterIndex)
+        {
+            ResolvePathsIfEmpty();
+            return Path.Combine(IndexesDir, projectName, fileFilterIndex);
+        }
+
+        private static void ResolvePathsIfEmpty()
+        {
+            if (String.IsNullOrEmpty(ConfigFilePath))
+            {
+                ConfigFilePath = ResolveConfigurationPath();
+                IndexesDir = ResolveIndexesDir(ConfigFilePath);
+            }
+        }
+
+        public static string ResolveConfigurationPath()
+        {
+            string path = GetPathFromAssembly();
+            if (File.Exists(path))
+                return path;
+
+            return GetPathFromLocalAppData();
+        }
+
+        private static string GetPathFromAssembly()
+        {
+            string directoryName = Path.GetDirectoryName(Assembly.GetExecutingAssembly().Location);
+            if (String.IsNullOrEmpty(directoryName))
+                return ConfigFileName;
+
+            return Path.Combine(directoryName, ConfigFileName);
+        }
+
+        private static string GetPathFromLocalAppData()
+        {
+            string localAppDataPath = Environment.GetFolderPath(Environment.SpecialFolder.LocalApplicationData);
+            if (!Directory.Exists(localAppDataPath))
+                throw new Exception($"Unable to find local app data directory '{localAppDataPath}'.");
+
+            string flashSearcherDataDir = Path.Combine(localAppDataPath, "FlashSearcher");
+            if (!Directory.Exists(flashSearcherDataDir))
+                Directory.CreateDirectory(flashSearcherDataDir);
+
+            return Path.Combine(flashSearcherDataDir, ConfigFileName);
+        }
+
+        private static string ResolveIndexesDir(string configFilePath)
+        {
+            string configFileDir = Path.GetDirectoryName(configFilePath);
+            return Path.Combine(configFileDir, "Indexes");
+        }
+    }
+}

--- a/FlashSearch.Configuration/ConfigurationPathResolver.cs
+++ b/FlashSearch.Configuration/ConfigurationPathResolver.cs
@@ -4,25 +4,25 @@ using System.Reflection;
 
 namespace FlashSearch.Configuration
 {
-    public static class ConfigurationPathResolver
+    public class ConfigurationPathResolver
     {
-        private static readonly String ConfigFileName = "SearchConfiguration.xml";
-        private static string ConfigFilePath = null;
-        private static string IndexesDir = null;
+        private readonly String ConfigFileName = "SearchConfiguration.xml";
+        private string ConfigFilePath = null;
+        private string IndexesDir = null;
 
-        public static string GetConfigurationPath()
+        public string GetConfigurationPath()
         {
             ResolvePathsIfEmpty();
             return ConfigFilePath;
         }
 
-        public static string GetIndexDir(string projectName, string fileFilterIndex)
+        public string GetIndexDir(string projectName, string fileFilterIndex)
         {
             ResolvePathsIfEmpty();
             return Path.Combine(IndexesDir, projectName, fileFilterIndex);
         }
 
-        private static void ResolvePathsIfEmpty()
+        private void ResolvePathsIfEmpty()
         {
             if (String.IsNullOrEmpty(ConfigFilePath))
             {
@@ -31,7 +31,7 @@ namespace FlashSearch.Configuration
             }
         }
 
-        public static string ResolveConfigurationPath()
+        public string ResolveConfigurationPath()
         {
             string path = GetPathFromAssembly();
             if (File.Exists(path))
@@ -40,7 +40,7 @@ namespace FlashSearch.Configuration
             return GetPathFromLocalAppData();
         }
 
-        private static string GetPathFromAssembly()
+        private string GetPathFromAssembly()
         {
             string directoryName = Path.GetDirectoryName(Assembly.GetExecutingAssembly().Location);
             if (String.IsNullOrEmpty(directoryName))
@@ -49,7 +49,7 @@ namespace FlashSearch.Configuration
             return Path.Combine(directoryName, ConfigFileName);
         }
 
-        private static string GetPathFromLocalAppData()
+        private string GetPathFromLocalAppData()
         {
             string localAppDataPath = Environment.GetFolderPath(Environment.SpecialFolder.LocalApplicationData);
             if (!Directory.Exists(localAppDataPath))
@@ -62,7 +62,7 @@ namespace FlashSearch.Configuration
             return Path.Combine(flashSearcherDataDir, ConfigFileName);
         }
 
-        private static string ResolveIndexesDir(string configFilePath)
+        private string ResolveIndexesDir(string configFilePath)
         {
             string configFileDir = Path.GetDirectoryName(configFilePath);
             return Path.Combine(configFileDir, "Indexes");

--- a/FlashSearch.Configuration/ConfigurationPathResolver.cs
+++ b/FlashSearch.Configuration/ConfigurationPathResolver.cs
@@ -44,7 +44,7 @@ namespace FlashSearch.Configuration
         {
             string directoryName = Path.GetDirectoryName(Assembly.GetExecutingAssembly().Location);
             if (String.IsNullOrEmpty(directoryName))
-                return ConfigFileName;
+                throw new Exception($"Unable to find executable's directory");
 
             return Path.Combine(directoryName, ConfigFileName);
         }

--- a/FlashSearch.Configuration/FlashSearch.Configuration.csproj
+++ b/FlashSearch.Configuration/FlashSearch.Configuration.csproj
@@ -38,6 +38,7 @@
     <Reference Include="System.Xml" />
   </ItemGroup>
   <ItemGroup>
+    <Compile Include="ConfigurationPathResolver.cs" />
     <Compile Include="ConfigurationWatcher.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
     <Compile Include="SearchConfiguration.cs" />

--- a/FlashSearch.Viewer/Services/GlobalFactory.cs
+++ b/FlashSearch.Viewer/Services/GlobalFactory.cs
@@ -17,11 +17,13 @@ namespace FlashSearch.Viewer.Services
 
             // Register File Service
             builder.RegisterType<FileService>().AsSelf().SingleInstance();
-            
+
+            string configurationPath = ConfigurationPathResolver.GetConfigurationPath();
+
             // Register Search Configuration
             builder.RegisterInstance(
                 new ConfigurationWatcher<SearchConfiguration>(
-                    GetConfigurationPath(), 
+                    configurationPath, 
                     XMLIO.Load<SearchConfiguration>,
                     XMLIO.Save,
                     () => SearchConfiguration.Default))
@@ -31,14 +33,6 @@ namespace FlashSearch.Viewer.Services
             ViewModelLocator.RegisterTypes(builder);
 
             Container = builder.Build();
-        }
-
-        static string GetConfigurationPath()
-        {
-            string directoryName = Path.GetDirectoryName(Assembly.GetExecutingAssembly().Location);
-            if (String.IsNullOrEmpty(directoryName))
-                throw new Exception("Unable to find executable's directory.");
-            return Path.Combine(directoryName, "SearchConfiguration.xml");
         }
     }
 }

--- a/FlashSearch.Viewer/Services/GlobalFactory.cs
+++ b/FlashSearch.Viewer/Services/GlobalFactory.cs
@@ -18,7 +18,10 @@ namespace FlashSearch.Viewer.Services
             // Register File Service
             builder.RegisterType<FileService>().AsSelf().SingleInstance();
 
-            string configurationPath = ConfigurationPathResolver.GetConfigurationPath();
+            ConfigurationPathResolver configPathResolver = new ConfigurationPathResolver();
+            builder.RegisterInstance(configPathResolver).AsSelf().SingleInstance();
+
+            string configurationPath = configPathResolver.GetConfigurationPath();
 
             // Register Search Configuration
             builder.RegisterInstance(

--- a/FlashSearch.Viewer/ViewModels/SearchViewModel.cs
+++ b/FlashSearch.Viewer/ViewModels/SearchViewModel.cs
@@ -242,8 +242,7 @@ namespace FlashSearch.Viewer.ViewModels
             _fileService.InvalidateCache();
             SearchInProgress = true;
             
-            string localDirectory = Path.GetDirectoryName(Assembly.GetExecutingAssembly().Location);
-            string indexDirectory = Path.Combine(localDirectory, "Indexes", SelectedProject.Name, SelectedFileFilter.Index);
+            string indexDirectory = ConfigurationPathResolver.GetIndexDir(SelectedProject.Name, SelectedFileFilter.Index);
             _luceneSearcher = new LuceneSearcher(indexDirectory);
             
             SelectedSearchResultViewModel = null;

--- a/FlashSearch.Viewer/ViewModels/SearchViewModel.cs
+++ b/FlashSearch.Viewer/ViewModels/SearchViewModel.cs
@@ -36,6 +36,7 @@ namespace FlashSearch.Viewer.ViewModels
         private readonly FileService _fileService;
         private SearchConfiguration _searchConfig;
         private readonly ConfigurationWatcher<SearchConfiguration> _searchConfigWatcher;
+        private readonly ConfigurationPathResolver _configPathResolver;
         
         private LuceneSearcher _luceneSearcher;
         private SmartContentSelector _smartContentSelector;
@@ -160,12 +161,15 @@ namespace FlashSearch.Viewer.ViewModels
         public RelayCommand CancelSearchCommand { get; }
         public RelayCommand OpenSettingsCommand { get; }
         
-        public SearchViewModel(FileService fileService, ConfigurationWatcher<SearchConfiguration> searchConfigWatcher)
+        public SearchViewModel(FileService fileService,
+            ConfigurationWatcher<SearchConfiguration> searchConfigWatcher,
+            ConfigurationPathResolver configPathResolver)
         {
             _fileService = fileService;
             _searchConfigWatcher = searchConfigWatcher;
             _searchConfigWatcher.ConfigurationUpdated += OnConfigurationUpdated;
             _searchConfig = searchConfigWatcher.GetConfiguration();
+            _configPathResolver = configPathResolver;
             _searchInProgress = false;
 
             Results = new ObservableCollection<SearchResultViewModel>();
@@ -242,7 +246,7 @@ namespace FlashSearch.Viewer.ViewModels
             _fileService.InvalidateCache();
             SearchInProgress = true;
             
-            string indexDirectory = ConfigurationPathResolver.GetIndexDir(SelectedProject.Name, SelectedFileFilter.Index);
+            string indexDirectory = _configPathResolver.GetIndexDir(SelectedProject.Name, SelectedFileFilter.Index);
             _luceneSearcher = new LuceneSearcher(indexDirectory);
             
             SelectedSearchResultViewModel = null;


### PR DESCRIPTION
The SearchConfiguration.xml file and search indexes were saved directly
at the location of the executing assembly, which meant that different
configuration and indexes were used when we ran the GUI Viewer vs the
CLI application or when we ran Debug vs Release. It also meant data
files were saved along with the binaries.

The new behavior first checks if there is a configuration file at the
location of the executing assembly and uses it if that's the case. That
allows backward compatibility for users that have their configuration at
that location. However, if there is no configuration at that location,
we now look into `%LocalAppData%/FlashSearcher` and save the default
configuration there if there's isn't one already. That allows sharing a
single configuration between GUI/CLI and Debug/Release, and saves user
data in her/his own folder.